### PR TITLE
Consistently use `HexEscapeSequence`s where applicable

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ module.exports = exports.default = function emailPropt({
   autoCompleteChars = new Set([
     '\t' /* tab */,
     '\r' /* return */,
-    '\u001b[C' /* right arrow */,
+    '\x1b[C' /* right arrow */,
     ' ' /* spacebar */
   ]),
   resolveChars = new Set(['\r']),
-  abortChars = new Set(['\u0003']),
+  abortChars = new Set(['\x03']),
   allowInvalidChars = false
 } = {}) {
   return new Promise((resolve, reject) => {
@@ -61,11 +61,11 @@ module.exports = exports.default = function emailPropt({
         val += suggestion;
         suggestion = '';
       } else {
-        if ('\u001b[D' === s) {
+        if ('\x1b[D' === s) {
           if (val.length > Math.abs(caretOffset)) {
             caretOffset--;
           }
-        } else if ('\u001b[C' === s) {
+        } else if ('\x1b[C' === s) {
           if (caretOffset < 0) {
             caretOffset++;
           }


### PR DESCRIPTION
For code points in the range from U+0000 to U+00FF there is no point in using a `UnicodeEscapeSequence` of the form `\u00ff` — so use `\xff` instead.
